### PR TITLE
Add support for public broadcast IP

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -97,6 +97,7 @@ type (
 	P2PConfig struct {
 		AlertSystemProtocolID string        `json:"alert_system_protocol_id" mapstructure:"alert_system_protocol_id"` // AlertSystemProtocolID is the protocol ID to use on the libp2p network for alert system communication
 		BootstrapPeer         string        `json:"bootstrap_peer" mapstructure:"bootstrap_peer"`                     // BootstrapPeer is the bootstrap peer for the libp2p network
+		BroadcastIP           string        `json:"broadcast_ip" mapstructure:"broadcast_ip"`                         // BroadcastIP is the public facing IP address to broadcast to other peers
 		IP                    string        `json:"ip" mapstructure:"ip"`                                             // IP is the IP address for the P2P server
 		Port                  string        `json:"port" mapstructure:"port"`                                         // Port is the port for the P2P server
 		PrivateKeyPath        string        `json:"private_key_path" mapstructure:"private_key_path"`                 // PrivateKeyPath is the path to the private key

--- a/app/config/envs/mainnet.json
+++ b/app/config/envs/mainnet.json
@@ -65,6 +65,7 @@
   "p2p": {
     "ip": "0.0.0.0",
     "port": "9906",
+    "broadcast_ip": "",
     "alert_system_protocol_id": "/bitcoin/alert-system/1.0.0",
     "bootstrap_peer": "",
     "private_key_path": "",

--- a/app/config/envs/stn.json
+++ b/app/config/envs/stn.json
@@ -67,6 +67,7 @@
     "port": "9906",
     "alert_system_protocol_id": "/bitcoin-stn/alert-system/0.0.1",
     "bootstrap_peer": "",
+    "broadcast_ip": "",
     "private_key_path": "",
     "topic_name": "bitcoin_alert_system_stn"
   },

--- a/app/config/envs/testnet.json
+++ b/app/config/envs/testnet.json
@@ -67,6 +67,7 @@
     "port": "9906",
     "alert_system_protocol_id": "/bitcoin-testnet/alert-system/0.0.1",
     "bootstrap_peer": "",
+    "broadcast_ip": "",
     "private_key_path": "",
     "topic_name": "bitcoin_alert_system_testnet"
   },


### PR DESCRIPTION
<!-- thank you for your contribution! ❤️  -->
`ALERT_SYSTEM_P2P__BROADCAST_IP` will now allow a user to set an external IP address.