### PR TITLE
Migrate go-bt to bsv-blockchain org

### DIFF
--- a/app/models/alert_message.go
+++ b/app/models/alert_message.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bitcoinschema/go-bitcoin"
 	"github.com/bitcoinsv/bsvd/bsvec"
 	"github.com/bitcoinsv/bsvutil"
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/mrz1836/go-datastore"
 )
 

--- a/app/models/alert_message_invalidate_block.go
+++ b/app/models/alert_message_invalidate_block.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/libsv/go-p2p/wire"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/bitcoinschema/go-bitcoin v0.3.20
 	github.com/bitcoinsv/bsvd v0.0.0-20190609155523-4c29707f7173
 	github.com/bitcoinsv/bsvutil v0.0.0-20181216182056-1d77cf353ea9
+	github.com/bsv-blockchain/go-bt/v2 v2.3.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/libp2p/go-libp2p v0.41.1
 	github.com/libp2p/go-libp2p-kad-dht v0.33.1
 	github.com/libp2p/go-libp2p-pubsub v0.14.1
 	github.com/libsv/go-bn v0.0.2
-	github.com/libsv/go-bt/v2 v2.2.5
 	github.com/libsv/go-p2p v0.3.3
 	github.com/mrz1836/go-api-router v0.11.3
 	github.com/mrz1836/go-datastore v0.9.5
@@ -95,6 +95,7 @@ require (
 	github.com/libsv/go-bc v0.1.29 // indirect
 	github.com/libsv/go-bk v0.1.6 // indirect
 	github.com/libsv/go-bt v1.0.8 // indirect
+	github.com/libsv/go-bt/v2 v2.2.5 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/matryer/respond v1.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -200,9 +201,6 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.38.0 // indirect
 )
-
-// Use this specific version of go-bt (ordishs vs libsv)
-replace github.com/libsv/go-bt/v2 => github.com/ordishs/go-bt/v2 v2.2.22
 
 // Use this specific version of go-bn (galt-tr vs libsv)
 replace github.com/libsv/go-bn => github.com/galt-tr/go-bn v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/bitcoinsv/bsvlog v0.0.0-20181216181007-cb81b076bf2e/go.mod h1:WPrWor6
 github.com/bitcoinsv/bsvutil v0.0.0-20181216182056-1d77cf353ea9 h1:hFI8rT84FCA0FFy3cFrkW5Nz4FyNKlIdCvEvvTNySKg=
 github.com/bitcoinsv/bsvutil v0.0.0-20181216182056-1d77cf353ea9/go.mod h1:p44KuNKUH5BC8uX4ONEODaHUR4+ibC8todEAOGQEJAM=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
+github.com/bsv-blockchain/go-bt/v2 v2.3.0 h1:ZEFtKV93wq59qna9/DEp4NJmVb5hZgF3h1vGXNLKMeU=
+github.com/bsv-blockchain/go-bt/v2 v2.3.0/go.mod h1:NzalErv8cCi3VDZYNLaHxnP2PiiDFIQS6dgQgBGTV4A=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -248,6 +250,8 @@ github.com/libsv/go-bk v0.1.6/go.mod h1:khJboDoH18FPUaZlzRFKzlVN84d4YfdmlDtdX4LA
 github.com/libsv/go-bt v1.0.4/go.mod h1:AfXoLFYEbY/TvCq/84xTce2xGjPUuC5imokHmcykF2k=
 github.com/libsv/go-bt v1.0.8 h1:nWLLcnUm0dxNO3exqrL5jvAcTGkl0dsnBuQqB6+M6vQ=
 github.com/libsv/go-bt v1.0.8/go.mod h1:yO023bNYLh5DwcOYl+ZqLAeTemoy6K+2UbQlIBMv+EQ=
+github.com/libsv/go-bt/v2 v2.2.5 h1:VoggBLMRW9NYoFujqe5bSYKqnw5y+fYfufgERSoubog=
+github.com/libsv/go-bt/v2 v2.2.5/go.mod h1:cV45+jDlPOLfhJLfpLmpQoWzrIvVth9Ao2ZO1f6CcqU=
 github.com/libsv/go-p2p v0.3.3 h1:5h+69MsGgFwQWyD8MEqyPeqbqKGRpKLzzOcI5cSLfgY=
 github.com/libsv/go-p2p v0.3.3/go.mod h1:TENFxbTT/bfSfuiirjU6l+PfAWxwZgF8GYUxs5tzc/M=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
@@ -329,8 +333,6 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU8lpJfSlR0xww=
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/ordishs/go-bt/v2 v2.2.22 h1:5WmTQoX74g9FADM9hpbXZOE34uep4EqeSwpIy4CbWYE=
-github.com/ordishs/go-bt/v2 v2.2.22/go.mod h1:bOaZFOoazYognJH/nfcBjuDFud1XmIc05n7bp4Tvvfk=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
This pull request updates dependencies in the `go.mod` file and adjusts import paths in related files to switch from `libsv/go-bt/v2` to `bsv-blockchain/go-bt/v2`. It removes an existing `replace` directive for `libsv/go-bt/v2` and ensures consistency across the codebase.

### Dependency updates:

* Updated the `go.mod` file to use `github.com/bsv-blockchain/go-bt/v2` version `v2.3.0` instead of `github.com/libsv/go-bt/v2` version `v2.2.5` for direct dependencies.
* Removed the `replace` directive for `github.com/libsv/go-bt/v2` to eliminate the override with `github.com/ordishs/go-bt/v2`.

### Import path adjustments:

* Changed the import path from `github.com/libsv/go-bt/v2/chainhash` to `github.com/bsv-blockchain/go-bt/v2/chainhash` in `app/models/alert_message.go`.
* Changed the import path from `github.com/libsv/go-bt/v2/chainhash` to `github.com/bsv-blockchain/go-bt/v2/chainhash` in `app/models/alert_message_invalidate_block.go`.

### Indirect dependency updates:

* Added `github.com/libsv/go-bt/v2` version `v2.2.5` as an indirect dependency in `go.mod`.<!-- thank you for your contribution! ❤️  -->
